### PR TITLE
Disable travis notifications to mongooseim at erlang solutions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ branches:
         only:
                 - master
 notifications:
-        email: mongoose-im@erlang-solutions.com
+        email: linearregression@example.com
 otp_release:
         - R16B01
         - R16B02


### PR DESCRIPTION
Hello @linearregression,

I didn't see any way to notify you via email, so here's a pull request ;)

The MongooseIM team at Erlang Solutions is getting Travis notifications about your builds.
Could you please change the notification email address in `.travis.yml` to your actual address?

Thanks & good luck with MongooseIM!
Simon
